### PR TITLE
Add applications for the BioEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ A list of models can be found [here](./src/models.yaml).
 
 ## How to contribute new models?
  1. Fork this repo
- 1. Add your models to the `src/models.yaml` file
+ 1. Add your models to the `src/manifest.model.yaml` file
  1. Run `python src/compile_model_manifest.py` to generate a new `manifest.model.json` with your models
  1. Commit your changes and send us a Pull Request.

--- a/manifest.model.json
+++ b/manifest.model.json
@@ -1,62 +1,67 @@
 {
+  "name": "BioImage Model Repository",
   "description": "The official bioimage model repository.",
+  "version": "0.1.0",
+  "url_root": "https://raw.githubusercontent.com/bioimage-io/models/master",
+  "applications": {
+    "ImJoy": "https://raw.githubusercontent.com/bioimage-io/models/master/src/Fiji-app.imjoy.html",
+    "Ilastik": "https://raw.githubusercontent.com/bioimage-io/models/master/src/Ilastik-app.imjoy.html",
+    "Fiji": "https://raw.githubusercontent.com/bioimage-io/models/master/src/ImJoy-app.imjoy.html"
+  },
   "models": [
     {
-      "applications": [
-        "Ilastik",
-        "ImJoy"
-      ],
-      "authors": [
-        "Constantin Pape;@bioimage-io",
-        "Fynn Beuttenm\u00fcller"
-      ],
-      "cite": [
-        {
-          "doi": "https://doi.org/10.1007/978-3-319-24574-4_28",
-          "text": "Ronneberger, Olaf et al. U-net: Convolutional networks for biomedical image segmentation. MICCAI 2015."
-        }
-      ],
-      "config_url": "UNet2DNucleiBroad.model.yaml",
-      "description": "A 2d U-Net pretrained on broad nucleus dataset.",
-      "documentation": "UNet2DNucleiBroad.md",
-      "download_url": "https://github.com/bioimage-io/pytorch-bioimage-io/archive/master.zip",
-      "name": "UNet2DNucleiBroad",
-      "root_url": "https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/master/specs/models/unet2d/nuclei_broad",
-      "tags": [
-        "unet2d",
-        "pytorch",
-        "nucleus-segmentation"
-      ]
-    },
-    {
-      "applications": [
-        "Ilastik"
-      ],
-      "authors": [
-        "Fynn Beuttenmueller"
-      ],
+      "root_url": "https://raw.githubusercontent.com/bioimage-io/python-bioimage-io/master/specs/models/sklearnbased",
+      "name": "sklearnRandomForestClassifierBroadNucleusData",
+      "description": "Random Forest Classifier form scikit-learn",
       "cite": [
         {
           "text": "L. Breiman, \"Random Forests\", Machine Learning, 45(1), 5-32, 2001",
           "url": "https://scikit-learn.org/stable/modules/generated/sklearnbased.ensemble.RandomForestClassifier.html"
         }
       ],
-      "config_url": "RandomForestClassifierBroadNucleusDataBinarized.model.yaml",
-      "description": "Random Forest Classifier form scikit-learn",
+      "authors": [
+        "Fynn Beuttenmueller"
+      ],
       "documentation": "sklearnbased.md",
-      "download_url": "https://github.com/bioimage-io/python-bioimage-io/archive/master.zip",
-      "name": "sklearnRandomForestClassifierBroadNucleusData",
-      "root_url": "https://raw.githubusercontent.com/bioimage-io/python-bioimage-io/master/specs/models/sklearnbased",
       "tags": [
         "test",
         "rf",
         "random",
         "forest",
         "example"
-      ]
+      ],
+      "config_url": "RandomForestClassifierBroadNucleusDataBinarized.model.yaml",
+      "applications": [
+        "Ilastik"
+      ],
+      "download_url": "https://github.com/bioimage-io/python-bioimage-io/archive/master.zip"
+    },
+    {
+      "root_url": "https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/master/specs/models/unet2d/nuclei_broad",
+      "name": "UNet2DNucleiBroad",
+      "description": "A 2d U-Net pretrained on broad nucleus dataset.",
+      "cite": [
+        {
+          "text": "Ronneberger, Olaf et al. U-net: Convolutional networks for biomedical image segmentation. MICCAI 2015.",
+          "doi": "https://doi.org/10.1007/978-3-319-24574-4_28"
+        }
+      ],
+      "authors": [
+        "Constantin Pape;@bioimage-io",
+        "Fynn Beuttenm\u00fcller"
+      ],
+      "documentation": "UNet2DNucleiBroad.md",
+      "tags": [
+        "unet2d",
+        "pytorch",
+        "nucleus-segmentation"
+      ],
+      "config_url": "UNet2DNucleiBroad.model.yaml",
+      "applications": [
+        "Ilastik",
+        "ImJoy"
+      ],
+      "download_url": "https://github.com/bioimage-io/pytorch-bioimage-io/archive/master.zip"
     }
-  ],
-  "name": "Bioimage model repository",
-  "uri_root": "",
-  "version": "0.1.0"
+  ]
 }

--- a/manifest.model.json
+++ b/manifest.model.json
@@ -30,7 +30,7 @@
         "forest",
         "example"
       ],
-      "config_url": "RandomForestClassifierBroadNucleusDataBinarized.model.yaml",
+      "config_url": "https://raw.githubusercontent.com/bioimage-io/python-bioimage-io/master/specs/models/sklearnbased/RandomForestClassifierBroadNucleusDataBinarized.model.yaml",
       "applications": [
         "Ilastik"
       ],
@@ -56,7 +56,7 @@
         "pytorch",
         "nucleus-segmentation"
       ],
-      "config_url": "UNet2DNucleiBroad.model.yaml",
+      "config_url": "https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/master/specs/models/unet2d/nuclei_broad/UNet2DNucleiBroad.model.yaml",
       "applications": [
         "Ilastik",
         "ImJoy"

--- a/src/Fiji-app.imjoy.html
+++ b/src/Fiji-app.imjoy.html
@@ -1,0 +1,43 @@
+<docs lang="markdown">
+    [TODO: write documentation for this plugin.]
+    </docs>
+    
+    <config lang="json">
+    {
+      "name": "Fiji Model Loader",
+      "type": "web-worker",
+      "tags": [],
+      "ui": "",
+      "version": "0.1.0",
+      "cover": "",
+      "description": "Fiji Model Loader for BioImage.io",
+      "icon": "extension",
+      "inputs": null,
+      "outputs": null,
+      "api_version": "0.1.7",
+      "env": "",
+      "permissions": [],
+      "requirements": [],
+      "dependencies": [],
+      "defaults": {"w": 20, "h": 10}
+    }
+    </config>
+    
+    <script lang="javascript">
+    class ImJoyPlugin {
+      async setup() {
+        api.log('initialized')
+      }
+    
+      async run(ctx) {
+        if(Array.isArray(ctx)){
+            api.alert(`NotImplemented: Load models (#${ctx.length}).`)
+        }
+        else{
+            api.alert(`NotImplemented: Load model "${ctx.name}" from "${ctx.config_url}".`)
+        }
+      }
+    }
+    
+    api.export(new ImJoyPlugin())
+    </script>

--- a/src/Ilastik-app.imjoy.html
+++ b/src/Ilastik-app.imjoy.html
@@ -1,0 +1,43 @@
+<docs lang="markdown">
+    [TODO: write documentation for this plugin.]
+    </docs>
+    
+    <config lang="json">
+    {
+      "name": "Ilastik Model Loader",
+      "type": "web-worker",
+      "tags": [],
+      "ui": "",
+      "version": "0.1.0",
+      "cover": "",
+      "description": "Ilastik Model Loader for BioImage.io",
+      "icon": "extension",
+      "inputs": null,
+      "outputs": null,
+      "api_version": "0.1.7",
+      "env": "",
+      "permissions": [],
+      "requirements": [],
+      "dependencies": [],
+      "defaults": {"w": 20, "h": 10}
+    }
+    </config>
+    
+    <script lang="javascript">
+    class ImJoyPlugin {
+      async setup() {
+        api.log('initialized')
+      }
+    
+      async run(ctx) {
+        if(Array.isArray(ctx)){
+            api.alert(`NotImplemented: Load models (#${ctx.length}).`)
+        }
+        else{
+            api.alert(`NotImplemented: Load model "${ctx.name}" from "${ctx.config_url}".`)
+        }
+      }
+    }
+    
+    api.export(new ImJoyPlugin())
+    </script>

--- a/src/ImJoy-app.imjoy.html
+++ b/src/ImJoy-app.imjoy.html
@@ -1,0 +1,43 @@
+<docs lang="markdown">
+[TODO: write documentation for this plugin.]
+</docs>
+
+<config lang="json">
+{
+  "name": "ImJoy Model Loader",
+  "type": "web-worker",
+  "tags": [],
+  "ui": "",
+  "version": "0.1.0",
+  "cover": "",
+  "description": "ImJoy Model Loader for BioImage.io",
+  "icon": "extension",
+  "inputs": null,
+  "outputs": null,
+  "api_version": "0.1.7",
+  "env": "",
+  "permissions": [],
+  "requirements": [],
+  "dependencies": [],
+  "defaults": {"w": 20, "h": 10}
+}
+</config>
+
+<script lang="javascript">
+class ImJoyPlugin {
+  async setup() {
+    api.log('initialized')
+  }
+
+  async run(ctx) {
+    if(Array.isArray(ctx)){
+        api.alert(`NotImplemented: Load models (#${ctx.length}).`)
+    }
+    else{
+        api.alert(`NotImplemented: Load model "${ctx.name}" from "${ctx.config_url}".`)
+    }
+  }
+}
+
+api.export(new ImJoyPlugin())
+</script>

--- a/src/compile_model_manifest.py
+++ b/src/compile_model_manifest.py
@@ -9,10 +9,16 @@ compiled_models = []
 preserved_keys = ["config_url", "applications", "download_url", "name", "description", "cite", "authors", "documentation", "tags", "covers"]
 assert 'url' not in preserved_keys
 
-model_list_file = Path('src/models.yaml')
-model_list = yaml.safe_load(model_list_file.read_text())
+models_yaml_file = Path('src/manifest.model.yaml')
+models_yaml = yaml.safe_load(models_yaml_file.read_text())
 
-for item in model_list:
+compiled_apps = {}
+for k in models_yaml['applications']:
+    app_url = models_yaml['applications'][k].strip('/').strip('./')
+    app_url = models_yaml['url_root'].strip('/') + '/' + app_url
+    compiled_apps[k] = app_url
+
+for item in models_yaml['models']:
     config_url = item['config_url']
     root_url = '/'.join(config_url.split('/')[:-1])
     response = requests.get(config_url)
@@ -40,9 +46,9 @@ for item in model_list:
             model_info[k] = model_config[k]
             
     compiled_models.append(model_info)
+    compiled_models.sort(key=lambda m: m['name'], reverse=True)
 
-template_to_read = Path('src/manifest_template.json')
-template = json.loads(template_to_read.read_text())
 with open('manifest.model.json', 'wb') as f:
-    template['models'] = compiled_models
-    f.write(json.dumps(template, sort_keys=True, indent=2, separators=(',', ': ')).encode('utf-8'))
+    models_yaml['models'] = compiled_models
+    models_yaml['applications'] = compiled_apps
+    f.write(json.dumps(models_yaml, indent=2, separators=(',', ': ')).encode('utf-8'))

--- a/src/compile_model_manifest.py
+++ b/src/compile_model_manifest.py
@@ -14,8 +14,10 @@ models_yaml = yaml.safe_load(models_yaml_file.read_text())
 
 compiled_apps = {}
 for k in models_yaml['applications']:
-    app_url = models_yaml['applications'][k].strip('/').strip('./')
-    app_url = models_yaml['url_root'].strip('/') + '/' + app_url
+    app_url = models_yaml['applications'][k]
+    if not app_url.startswith('http'):
+        app_url = models_yaml['applications'][k].strip('/').strip('./')
+        app_url = models_yaml['url_root'].strip('/') + '/' + app_url
     compiled_apps[k] = app_url
 
 for item in models_yaml['models']:
@@ -32,8 +34,6 @@ for item in models_yaml['models']:
     model_config.update(item)
     model_info = {"root_url": root_url}
     for k in model_config:
-        if k == 'config_url':
-            model_config[k] = config_url.split('/')[-1]
         # normalize relative path
         if k in ['documentation']:
             model_config[k] = model_config[k].strip('/').strip('./')

--- a/src/manifest.model.yaml
+++ b/src/manifest.model.yaml
@@ -1,3 +1,14 @@
+name: BioImage Model Repository
+description: The official bioimage model repository.
+version: 0.1.0
+url_root: https://raw.githubusercontent.com/bioimage-io/models/master
+
+applications:
+  ImJoy: src/Fiji-app.imjoy.html
+  Ilastik: src/Ilastik-app.imjoy.html
+  Fiji: src/ImJoy-app.imjoy.html
+
+models:
 - UNet2DNucleiBroad:
   config_url: https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/master/specs/models/unet2d/nuclei_broad/UNet2DNucleiBroad.model.yaml
   applications: [Ilastik, ImJoy]

--- a/src/manifest_template.json
+++ b/src/manifest_template.json
@@ -1,8 +1,0 @@
-{
-    "name": "Bioimage model repository",
-    "description": "The official bioimage model repository.",
-    "version": "0.1.0",
-    "uri_root": "",
-    "models": [
-    ]
-  }


### PR DESCRIPTION
This PR add applications to the manifest template. 
The manifest template (`src/manifest.model.yaml`) has the following format:
```yaml
name: BioImage Model Repository
description: The official bioimage model repository.
version: 0.1.0

applications:
 # specify the plugin file for launching the corresponding app in the bioengine
 Ilastik: src/Ilastik-app.imjoy.html 

models:
 - UNet2DNucleiBroad:
  config_url: ...
  applications: [Ilastik, ImJoy]
```

In the plugin file, we can either show a simple dialog with documentation, or run the model via a remote plugin engine.