### PR TITLE
add UNet2DNucleiBroad, add UNet3DArabidopsisOvules

### DIFF
--- a/manifest.model.json
+++ b/manifest.model.json
@@ -10,35 +10,8 @@
   },
   "models": [
     {
-      "root_url": "https://raw.githubusercontent.com/bioimage-io/python-bioimage-io/master/specs/models/sklearnbased",
-      "name": "sklearnRandomForestClassifierBroadNucleusData",
-      "description": "Random Forest Classifier form scikit-learn",
-      "cite": [
-        {
-          "text": "L. Breiman, \"Random Forests\", Machine Learning, 45(1), 5-32, 2001",
-          "url": "https://scikit-learn.org/stable/modules/generated/sklearnbased.ensemble.RandomForestClassifier.html"
-        }
-      ],
-      "authors": [
-        "Fynn Beuttenmueller"
-      ],
-      "documentation": "sklearnbased.md",
-      "tags": [
-        "test",
-        "rf",
-        "random",
-        "forest",
-        "example"
-      ],
-      "config_url": "https://raw.githubusercontent.com/bioimage-io/python-bioimage-io/master/specs/models/sklearnbased/RandomForestClassifierBroadNucleusDataBinarized.model.yaml",
-      "applications": [
-        "Ilastik"
-      ],
-      "download_url": "https://github.com/bioimage-io/python-bioimage-io/archive/master.zip"
-    },
-    {
-      "root_url": "https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/master/specs/models/unet2d/nuclei_broad",
-      "name": "UNet2DNucleiBroad",
+      "root_url": "https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/v0.1/specs/models/unet2d/nuclei_broad",
+      "name": "2D UNet Nuclei Broad",
       "description": "A 2d U-Net pretrained on broad nucleus dataset.",
       "cite": [
         {
@@ -56,13 +29,13 @@
         "pytorch",
         "nucleus-segmentation"
       ],
-      "config_url": "https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/master/specs/models/unet2d/nuclei_broad/UNet2DNucleiBroad.model.yaml",
+      "covers": [],
+      "config_url": "https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/v0.1/specs/models/unet2d/nuclei_broad/UNet2DNucleiBroad.model.yaml",
       "applications": [
-        "Fiji",
         "Ilastik",
         "ImJoy"
       ],
-      "download_url": "https://github.com/bioimage-io/pytorch-bioimage-io/archive/master.zip"
+      "download_url": "https://github.com/bioimage-io/pytorch-bioimage-io/releases/download/v0.1/UNet2DNucleiBroad.model.zip"
     }
   ]
 }

--- a/src/manifest.model.yaml
+++ b/src/manifest.model.yaml
@@ -10,11 +10,6 @@ applications:
 
 models:
 - UNet2DNucleiBroad:
-  config_url: https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/master/specs/models/unet2d/nuclei_broad/UNet2DNucleiBroad.model.yaml
-  applications: [Fiji, Ilastik, ImJoy]
-  download_url: https://github.com/bioimage-io/pytorch-bioimage-io/archive/master.zip
-
-- RandomForestClassifierBroadNucleusDataBinarized:
-  config_url: https://raw.githubusercontent.com/bioimage-io/python-bioimage-io/master/specs/models/sklearnbased/RandomForestClassifierBroadNucleusDataBinarized.model.yaml
-  applications: [Ilastik]
-  download_url: https://github.com/bioimage-io/python-bioimage-io/archive/master.zip
+  config_url: https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/v0.1/specs/models/unet2d/nuclei_broad/UNet2DNucleiBroad.model.yaml
+  applications: [Ilastik, ImJoy]
+  download_url: https://github.com/bioimage-io/pytorch-bioimage-io/releases/download/v0.1/UNet2DNucleiBroad.model.zip


### PR DESCRIPTION
and remove RandomForestClassifierBroadNucleusDataBinarized (weights can't be loaded yet)

requires https://github.com/wolny/pytorch-3dunet/pull/65 for UNet3DArabidopsisOvules
