### PR TITLE
Add BioEngine App for Ilastik

### DIFF
--- a/src/Ilastik-app.imjoy.html
+++ b/src/Ilastik-app.imjoy.html
@@ -26,7 +26,7 @@ This is a BioEngine App for running models on https://bioimage.io
         "https://static.imjoy.io/spectre.css/spectre-icons.min.css"
     ],
     "dependencies": ["https://gist.githubusercontent.com/oeway/2d4b5899424a14d8e90ad908d4cec364/raw/TiktorchModelLoader.imjoy.html", "https://gist.githubusercontent.com/oeway/f09955746ec01a20053793aba83c3545/raw/CompareImages.imjoy.html"],
-    "defaults": {"w": 20, "h": 10, "as_dialog": true}
+    "defaults": {"w": 20, "h": 10}
 }
 </config>
 

--- a/src/Ilastik-app.imjoy.html
+++ b/src/Ilastik-app.imjoy.html
@@ -20,7 +20,7 @@ This is a BioEngine App for running models on https://bioimage.io
     "flags": [],
     "env": ["conda create -n ilastik", {"type": "binder", "spec": "oeway/tiktorch-binder-image/master", "skip_requirements": true}],
     "requirements": ["git+git://github.com/bioimage-io/pytorch-bioimage-io.git#egg=pybio.torch", "pip:git+git://github.com/bioimage-io/pytorch-bioimage-io.git#egg=pybio.torch"],
-    "dependencies": []
+    "dependencies": ["https://gist.githubusercontent.com/oeway/f09955746ec01a20053793aba83c3545/raw/CompareImages.imjoy.html"]
 }
 </config>
 
@@ -77,7 +77,7 @@ class ImJoyPlugin():
         imgurl1 = array2base64(self.input_img[:512, :512, 0])
         imgurl2 = array2base64(prediction[0])
         api.showMessage('Done.')
-        api.showDialog({'type': 'imjoy/image-compare', 'name': 'Ilastik Demo', 'data': {"first": imgurl1, 'second': imgurl2, 'name': 'Process with frangiVesselness in ImageJ'}})
+        api.showDialog({'type': 'CompareImages', 'name': 'Ilastik Demo', 'data': {"first": imgurl1, 'second': imgurl2, 'name': 'Process with frangiVesselness in ImageJ'}})
     
     def runManyModels(self, model_config_list):
         api.alert('This feature is not implemented yet, please try the Ilastik icon on a individual model.')

--- a/src/Ilastik-app.imjoy.html
+++ b/src/Ilastik-app.imjoy.html
@@ -33,78 +33,79 @@ This is a BioEngine App for running models on https://bioimage.io
 <script lang="javascript">
 class ImJoyPlugin {
     async setup() {
-    api.log('initialized')
+        api.log('initialized')
     }
 
     runOneModel(model_info){
-    document.getElementById('model_name').innerHTML = model_info.name;
-    document.getElementById('model_description').innerHTML = model_info.description;
-    window.downloadModel = function(){
-        window.open(model_info.download_url);
-    }
-    window.loadImage = async function(){
-        const ret = await api.confirm('Would you like to an image file with the BioEngine? Otherwise, an example image will be used.')
-        if(ret){
-            document.getElementById('upload_file').click()
+        document.getElementById('model_name').innerHTML = model_info.name;
+        document.getElementById('model_description').innerHTML = model_info.description;
+        document.getElementById('cover').src = model_info.cover && model_info.cover[0];
+        window.downloadModel = function(){
+            window.open(model_info.download_url);
         }
-        else{
-            await window.runDemo();
+        window.loadImage = async function(){
+            const ret = await api.confirm('Would you like to an image file with the BioEngine? Otherwise, an example image will be used.')
+            if(ret){
+                document.getElementById('upload_file').click()
+            }
+            else{
+                await window.runDemo();
+            }
+            
         }
-        
-    }
-    window.fileChanged = async function(){
-        try{
-        document.getElementById('loading').style.display = 'block'
-        const file = document.getElementById('upload_file').files[0]
-        if(file){
-            await window.runDemo(file)
-        }
-        else{
-            api.showMessage('No file selected.')
-        }
-        
-        }
-        finally{
-        document.getElementById('loading').style.display = 'none'
-        }
-    }
-
-    window.runDemo = async function(file){
-        const p = await api.getPlugin('Tiktorch Model Loader')
-        const manager_url = await p.get_file_manager()
-        const fm = await api.getFileManager(manager_url)
-        
-        let ret;
-        if(file){
-        await fm.putFile(file, file.name)
-        const img_url = await p.preview_image(file.name)
-        document.getElementById('result').innerHTML =`<img class="img-responsive" src="${img_url}"></img>`
-        ret = await p.run_model(model_info.download_url, file.name)
-        }
-        else{
-        ret = await p.run_model(model_info.download_url, 'https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/v0.1.1/specs/models/unet2d/nuclei_broad/cover0.png')
+        window.fileChanged = async function(){
+            try{
+            document.getElementById('loading').style.display = 'block'
+            const file = document.getElementById('upload_file').files[0]
+            if(file){
+                await window.runDemo(file)
+            }
+            else{
+                api.showMessage('No file selected.')
+            }
+            
+            }
+            finally{
+            document.getElementById('loading').style.display = 'none'
+            }
         }
 
-        document.getElementById('result').innerHTML =`
-<div class="comparison-slider" style="height: ${ret.height}px; width: ${ret.width}px;">
-    <figure class="comparison-before">
-    <!-- image (before) -->
-    <img class="rounded" src="${ret.inputs}"></img>
-    <div class="comparison-label">Before</div>
-    </figure>
+        window.runDemo = async function(file){
+            const p = await api.getPlugin('Tiktorch Model Loader')
+            const manager_url = await p.get_file_manager()
+            const fm = await api.getFileManager(manager_url)
+            
+            let ret;
+            if(file){
+            await fm.putFile(file, file.name)
+            const img_url = await p.preview_image(file.name)
+            document.getElementById('result').innerHTML =`<img class="img-responsive" src="${img_url}"></img>`
+            ret = await p.run_model(model_info.download_url, file.name)
+            }
+            else{
+            ret = await p.run_model(model_info.download_url, 'https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/v0.1.1/specs/models/unet2d/nuclei_broad/cover0.png')
+            }
 
-    <figure class="comparison-after">
-    <!-- image (after) -->
-    <img class="filter-grayscale rounded" src="${ret.outputs}"></img>
-    <div class="comparison-label">After</div>
-    <textarea class="comparison-resizer" readonly></textarea>
-    </figure>
-</div>`
-    }
+            document.getElementById('result').innerHTML =`
+    <div class="comparison-slider" style="height: ${ret.height}px; width: ${ret.width}px;">
+        <figure class="comparison-before">
+        <!-- image (before) -->
+        <img class="rounded" src="${ret.inputs}"></img>
+        <div class="comparison-label">Before</div>
+        </figure>
+
+        <figure class="comparison-after">
+        <!-- image (after) -->
+        <img class="filter-grayscale rounded" src="${ret.outputs}"></img>
+        <div class="comparison-label">After</div>
+        <textarea class="comparison-resizer" readonly></textarea>
+        </figure>
+    </div>`
+        }
     }
 
     async run(ctx) {
-    this.runOneModel({name: "2D UNet Nuclei Broad", description: "", download_url: "https://github.com/bioimage-io/pytorch-bioimage-io/releases/download/v0.1.1/UNet2DNucleiBroad.model.zip"})
+        this.runOneModel({name: "2D UNet Nuclei Broad", description: "", download_url: "https://github.com/bioimage-io/pytorch-bioimage-io/releases/download/v0.1.1/UNet2DNucleiBroad.model.zip"})
     }
 }
 
@@ -126,7 +127,7 @@ api.export(new ImJoyPlugin())
             <br>
             <div class="card-subtitle">This model requires Ilastik, if you don't have it, download from <a href="https://www.ilastik.org/download.html" target="_blank">here</a></div>
         <div class="card-image" id="result">
-            <img class="img-responsive" src="https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/v0.1.1/specs/models/unet2d/nuclei_broad/cover0.png"></img>
+            <img class="img-responsive" id="cover" src=""></img>
             
         </div>
         </div>

--- a/src/Ilastik-app.imjoy.html
+++ b/src/Ilastik-app.imjoy.html
@@ -39,7 +39,7 @@ class ImJoyPlugin {
     runOneModel(model_info){
         document.getElementById('model_name').innerHTML = model_info.name;
         document.getElementById('model_description').innerHTML = model_info.description;
-        document.getElementById('cover').src = model_info.cover && model_info.cover[0];
+        document.getElementById('cover').src = model_info.cover_image && model_info.cover_image;
         window.downloadModel = function(){
             window.open(model_info.download_url);
         }

--- a/src/Ilastik-app.imjoy.html
+++ b/src/Ilastik-app.imjoy.html
@@ -8,85 +8,144 @@ This is a BioEngine App for running models on https://bioimage.io
 <config lang="json">
 {
     "name": "Ilastik Model Preview",
-    "type": "native-python",
-    "version": "0.1.0",
-    "api_version": "0.1.2",
-    "description": "Ilastik Model Preview for BioImage.io",
-    "icon": "https://raw.githubusercontent.com/bioimage-io/models/master/assets/icons/Ilastik-icon.png",
+    "type": "window",
     "tags": [],
     "ui": "",
+    "version": "0.1.0",
+    "cover": "",
+    "description": "Ilastik Model Preview for BioImage.io",
+    "icon": "https://raw.githubusercontent.com/bioimage-io/models/master/assets/icons/Ilastik-icon.png",
     "inputs": null,
     "outputs": null,
-    "flags": [],
-    "env": ["conda create -n ilastik", {"type": "binder", "spec": "oeway/tiktorch-binder-image/master", "skip_requirements": true}],
-    "requirements": ["git+git://github.com/bioimage-io/pytorch-bioimage-io.git#egg=pybio.torch", "pip:git+git://github.com/bioimage-io/pytorch-bioimage-io.git#egg=pybio.torch"],
-    "dependencies": ["https://gist.githubusercontent.com/oeway/f09955746ec01a20053793aba83c3545/raw/CompareImages.imjoy.html"]
+    "api_version": "0.1.7",
+    "env": "",
+    "permissions": [],
+    "requirements": [
+        "https://static.imjoy.io/spectre.css/spectre.min.css",
+        "https://static.imjoy.io/spectre.css/spectre-exp.min.css",
+        "https://static.imjoy.io/spectre.css/spectre-icons.min.css"
+    ],
+    "dependencies": ["https://gist.githubusercontent.com/oeway/2d4b5899424a14d8e90ad908d4cec364/raw/TiktorchModelLoader.imjoy.html", "https://gist.githubusercontent.com/oeway/f09955746ec01a20053793aba83c3545/raw/CompareImages.imjoy.html"],
+    "defaults": {"w": 20, "h": 10, "as_dialog": true}
 }
 </config>
 
-<script lang="python">
-from imjoy import api
-import numpy as np
-from PIL import Image
-import urllib.request
-import base64
-from io import BytesIO
-import torch
-from imageio import imread
-import zipfile
-from tiktorch.server.reader import eval_model_zip
+<script lang="javascript">
+class ImJoyPlugin {
+    async setup() {
+    api.log('initialized')
+    }
 
-def array2base64(img):
-    img = img/(img.max())*255.0
-    img = Image.fromarray(img.astype('uint8'))
-    byte_io = BytesIO()
-    img.save(byte_io, 'PNG')
-    result = base64.b64encode(byte_io.getvalue()).decode('ascii')
-    imgurl = 'data:image/png;base64,' + result
-    return imgurl
-
-class ImJoyPlugin():
-    async def setup(self) -> None:
-        self.exemplum = None
-        self.exemplum_url = None
-        self.img_url = None
-        self.input_img = None
-        api.log("initialized")
-
-    def runOneModel(self, model_config) -> None:
-        model_url = model_config['download_url']
-        if self.exemplum_url != model_url:
-            api.showMessage('Loading model from ' + model_url)
-            urllib.request.urlretrieve(model_url, 'tiktorch_model.zip')
-            with zipfile.ZipFile('tiktorch_model.zip', "r") as model_zip:
-                self.exemplum = eval_model_zip(model_zip, devices=[f"cuda:{i}" for i in range(torch.cuda.device_count())] + ["cpu"])
-                self.exemplum_url = model_url
+    runOneModel(model_info){
+    document.getElementById('model_name').innerHTML = model_info.name;
+    document.getElementById('model_description').innerHTML = model_info.description;
+    window.downloadModel = function(){
+        window.open(model_info.download_url);
+    }
+    window.loadImage = async function(){
+        const ret = await api.confirm('Would you like to an image file with the BioEngine? Otherwise, an example image will be used.')
+        if(ret){
+            document.getElementById('upload_file').click()
+        }
+        else{
+            await window.runDemo();
+        }
         
-        api.showMessage('Loading example image...')
-        image_url = 'https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/v0.1.1/specs/models/unet2d/nuclei_broad/cover0.png'
-        if self.img_url != image_url:
-            self.input_img = imread(image_url)
-            assert self.input_img.shape[2] == 4
-            self.img_url = image_url
+    }
+    window.fileChanged = async function(){
+        try{
+        document.getElementById('loading').style.display = 'block'
+        const file = document.getElementById('upload_file').files[0]
+        if(file){
+            await window.runDemo(file)
+        }
+        else{
+            api.showMessage('No file selected.')
+        }
+        
+        }
+        finally{
+        document.getElementById('loading').style.display = 'none'
+        }
+    }
 
-        batch = self.input_img[None, :512, :512, 0]  # cyx
-        api.showMessage('Running model inference...')
-        prediction = self.exemplum.forward(batch)
+    window.runDemo = async function(file){
+        const p = await api.getPlugin('Tiktorch Model Loader')
+        const manager_url = await p.get_file_manager()
+        const fm = await api.getFileManager(manager_url)
+        
+        let ret;
+        if(file){
+        await fm.putFile(file, file.name)
+        const img_url = await p.preview_image(file.name)
+        document.getElementById('result').innerHTML =`<img class="img-responsive" src="${img_url}"></img>`
+        ret = await p.run_model(model_info.download_url, file.name)
+        }
+        else{
+        ret = await p.run_model(model_info.download_url, 'https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/v0.1.1/specs/models/unet2d/nuclei_broad/cover0.png')
+        }
 
-        api.showMessage('Displaying results...')
-        imgurl1 = array2base64(self.input_img[:512, :512, 0])
-        imgurl2 = array2base64(prediction[0])
-        api.showMessage('Done.')
-        api.showDialog({'type': 'CompareImages', 'name': 'Ilastik Demo', 'data': {"first": imgurl1, 'second': imgurl2, 'name': 'Process with frangiVesselness in ImageJ'}})
-    
-    def runManyModels(self, model_config_list):
-        api.alert('This feature is not implemented yet, please try the Ilastik icon on a individual model.')
-        api.log(str(model_config_list))
+        document.getElementById('result').innerHTML =`
+<div class="comparison-slider" style="height: ${ret.height}px; width: ${ret.width}px;">
+    <figure class="comparison-before">
+    <!-- image (before) -->
+    <img class="rounded" src="${ret.inputs}"></img>
+    <div class="comparison-label">Before</div>
+    </figure>
 
-    def run(self, ctx):
-        self.runOneModel({"download_url": "https://github.com/bioimage-io/pytorch-bioimage-io/releases/download/v0.1.1/UNet2DNucleiBroad.model.zip"})
+    <figure class="comparison-after">
+    <!-- image (after) -->
+    <img class="filter-grayscale rounded" src="${ret.outputs}"></img>
+    <div class="comparison-label">After</div>
+    <textarea class="comparison-resizer" readonly></textarea>
+    </figure>
+</div>`
+    }
+    }
 
+    async run(ctx) {
+    this.runOneModel({name: "2D UNet Nuclei Broad", description: "", download_url: "https://github.com/bioimage-io/pytorch-bioimage-io/releases/download/v0.1.1/UNet2DNucleiBroad.model.zip"})
+    }
+}
 
-api.export(ImJoyPlugin())
+api.export(new ImJoyPlugin())
 </script>
-  
+
+<window lang="html">
+    <div>
+    <div class="loading loading-lg floating" style="display: none;" id="loading"></div>
+    <div class="model-info">
+        <div class="card">
+            <div class="card-header">
+            <h1 id="model_name">Ilastik Model</h1>
+            <p id="model_description"></p>
+            <button class="btn " onclick="downloadModel()">Download for Ilastik</button>
+            <button class="btn btn-primary" onclick="loadImage()">Run Model with BioEngine</button>
+            <input type="file" onchange="fileChanged()" style="display:none;" id="upload_file"/>
+            </div>
+            <br>
+            <div class="card-subtitle">This model requires Ilastik, if you don't have it, download from <a href="https://www.ilastik.org/download.html" target="_blank">here</a></div>
+        <div class="card-image" id="result">
+            <img class="img-responsive" src="https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/v0.1.1/specs/models/unet2d/nuclei_broad/cover0.png"></img>
+            
+        </div>
+        </div>
+
+    </div>
+</window>
+
+<style lang="css">
+.model-info{
+    padding: 10px;
+}
+.card{
+    padding: 10px 20px;
+}
+.floating {
+    position: absolute !important;
+    left: calc( 50% - 2px ) !important;
+    top: calc( 50% ) !important;
+    z-index: 999;
+}
+</style>
+    

--- a/src/Ilastik-app.imjoy.html
+++ b/src/Ilastik-app.imjoy.html
@@ -1,5 +1,5 @@
 <docs lang="markdown">
-## Ilastik Model Loader for BioImage.io
+## Ilastik Model Preview for BioImage.io
 
 This is a BioEngine App for running models on https://bioimage.io
 
@@ -7,11 +7,11 @@ This is a BioEngine App for running models on https://bioimage.io
 
 <config lang="json">
 {
-    "name": "Ilastik Model Loader",
+    "name": "Ilastik Model Preview",
     "type": "native-python",
     "version": "0.1.0",
     "api_version": "0.1.2",
-    "description": "Ilastik Model Loader for BioImage.io",
+    "description": "Ilastik Model Preview for BioImage.io",
     "icon": "https://raw.githubusercontent.com/bioimage-io/models/master/assets/icons/Ilastik-icon.png",
     "tags": [],
     "ui": "",

--- a/src/Ilastik-app.imjoy.html
+++ b/src/Ilastik-app.imjoy.html
@@ -44,7 +44,7 @@ class ImJoyPlugin {
             window.open(model_info.download_url);
         }
         window.loadImage = async function(){
-            const ret = await api.confirm('Would you like to an image file with the BioEngine? Otherwise, an example image will be used.')
+            const ret = await api.confirm('Would you like to an image file with the BioEngine? Otherwise, an example image will be used. Note: you need an image with size 512x512.')
             if(ret){
                 document.getElementById('upload_file').click()
             }
@@ -55,18 +55,18 @@ class ImJoyPlugin {
         }
         window.fileChanged = async function(){
             try{
-            document.getElementById('loading').style.display = 'block'
-            const file = document.getElementById('upload_file').files[0]
-            if(file){
-                await window.runDemo(file)
-            }
-            else{
-                api.showMessage('No file selected.')
-            }
-            
+                document.getElementById('loading').style.display = 'block'
+                const file = document.getElementById('upload_file').files[0]
+                if(file){
+                    await window.runDemo(file)
+                }
+                else{
+                    api.showMessage('No file selected.')
+                }
+                
             }
             finally{
-            document.getElementById('loading').style.display = 'none'
+                document.getElementById('loading').style.display = 'none'
             }
         }
 
@@ -77,13 +77,13 @@ class ImJoyPlugin {
             
             let ret;
             if(file){
-            await fm.putFile(file, file.name)
-            const img_url = await p.preview_image(file.name)
-            document.getElementById('result').innerHTML =`<img class="img-responsive" src="${img_url}"></img>`
-            ret = await p.run_model(model_info.download_url, file.name)
+                await fm.putFile(file, file.name)
+                const img_url = await p.preview_image(file.name)
+                document.getElementById('result').innerHTML =`<img class="img-responsive" src="${img_url}"></img>`
+                ret = await p.run_model(model_info.download_url, file.name)
             }
             else{
-            ret = await p.run_model(model_info.download_url, 'https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/v0.1.1/specs/models/unet2d/nuclei_broad/cover0.png')
+                ret = await p.run_model(model_info.download_url, 'https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/v0.1.1/specs/models/unet2d/nuclei_broad/cover0.png')
             }
 
             document.getElementById('result').innerHTML =`
@@ -98,9 +98,10 @@ class ImJoyPlugin {
         <!-- image (after) -->
         <img class="filter-grayscale rounded" src="${ret.outputs}"></img>
         <div class="comparison-label">After</div>
-        <textarea class="comparison-resizer" readonly></textarea>
+        <textarea class="comparison-resizer" style="width: 100px;" readonly></textarea>
         </figure>
     </div>`
+        document.getElementsByClassName('comparison-resizer')[0].style.width = ret.width + 'px';
         }
     }
 
@@ -118,7 +119,7 @@ api.export(new ImJoyPlugin())
     <div class="model-info">
         <div class="card">
             <div class="card-header">
-            <h1 id="model_name">Ilastik Model</h1>
+            <h2 id="model_name">Ilastik Model</h2>
             <p id="model_description"></p>
             <button class="btn " onclick="downloadModel()">Download for Ilastik</button>
             <button class="btn btn-primary" onclick="loadImage()">Run Model with BioEngine</button>
@@ -126,10 +127,9 @@ api.export(new ImJoyPlugin())
             </div>
             <br>
             <div class="card-subtitle">This model requires Ilastik, if you don't have it, download from <a href="https://www.ilastik.org/download.html" target="_blank">here</a></div>
-        <div class="card-image" id="result">
-            <img class="img-responsive" id="cover" src=""></img>
-            
-        </div>
+            <div class="card-image" id="result">
+                <img class="img-responsive" id="cover" src=""></img>
+            </div>
         </div>
 
     </div>
@@ -145,7 +145,7 @@ api.export(new ImJoyPlugin())
 .floating {
     position: absolute !important;
     left: calc( 50% - 2px ) !important;
-    top: calc( 50% ) !important;
+    top: calc( 30% ) !important;
     z-index: 999;
 }
 </style>

--- a/src/Ilastik-app.imjoy.html
+++ b/src/Ilastik-app.imjoy.html
@@ -1,50 +1,92 @@
 <docs lang="markdown">
-[TODO: write documentation for this plugin.]
+## Ilastik Model Loader for BioImage.io
+
+This is a BioEngine App for running models on https://bioimage.io
+
 </docs>
 
 <config lang="json">
 {
-  "name": "Ilastik Model Loader",
-  "type": "web-worker",
-  "tags": [],
-  "ui": "",
-  "version": "0.1.0",
-  "cover": "",
-  "description": "Ilastik Model Loader for BioImage.io",
-  "icon": "https://raw.githubusercontent.com/bioimage-io/models/master/assets/icons/Ilastik-icon.png",
-  "inputs": null,
-  "outputs": null,
-  "api_version": "0.1.7",
-  "env": "",
-  "permissions": [],
-  "requirements": [],
-  "dependencies": [],
-  "defaults": {"w": 20, "h": 10}
+    "name": "Ilastik Model Loader",
+    "type": "native-python",
+    "version": "0.1.0",
+    "api_version": "0.1.2",
+    "description": "Ilastik Model Loader for BioImage.io",
+    "icon": "https://raw.githubusercontent.com/bioimage-io/models/master/assets/icons/Ilastik-icon.png",
+    "tags": [],
+    "ui": "",
+    "inputs": null,
+    "outputs": null,
+    "flags": [],
+    "env": ["conda create -n ilastik", {"type": "binder", "spec": "oeway/tiktorch-binder-image/master", "skip_requirements": true}],
+    "requirements": ["git+git://github.com/bioimage-io/pytorch-bioimage-io.git#egg=pybio.torch", "pip:git+git://github.com/bioimage-io/pytorch-bioimage-io.git#egg=pybio.torch"],
+    "dependencies": []
 }
 </config>
 
-<script lang="javascript">
-class ImJoyPlugin {
-  async setup() {
-    api.log('initialized')
-  }
-  
-  runOneModel(model_info){
-    api.alert(`Ilastik gets model "${model_info.name}".`)
-  }
+<script lang="python">
+from imjoy import api
+import numpy as np
+from PIL import Image
+import urllib.request
+import base64
+from io import BytesIO
+import torch
+from imageio import imread
+import zipfile
+from tiktorch.server.reader import eval_model_zip
 
-  runManyModels(model_info_list){
-    api.alert(`Ilastik gets ${model_info_list.length} models.`)
-  }
+def array2base64(img):
+    img = img/(img.max())*255.0
+    img = Image.fromarray(img.astype('uint8'))
+    byte_io = BytesIO()
+    img.save(byte_io, 'PNG')
+    result = base64.b64encode(byte_io.getvalue()).decode('ascii')
+    imgurl = 'data:image/png;base64,' + result
+    return imgurl
 
-  testModel(){
+class ImJoyPlugin():
+    async def setup(self) -> None:
+        self.exemplum = None
+        self.exemplum_url = None
+        self.img_url = None
+        self.input_img = None
+        api.log("initialized")
 
-  }
+    def runOneModel(self, model_config) -> None:
+        model_url = model_config['download_url']
+        if self.exemplum_url != model_url:
+            api.showMessage('Loading model from ' + model_url)
+            urllib.request.urlretrieve(model_url, 'tiktorch_model.zip')
+            with zipfile.ZipFile('tiktorch_model.zip', "r") as model_zip:
+                self.exemplum = eval_model_zip(model_zip, devices=[f"cuda:{i}" for i in range(torch.cuda.device_count())] + ["cpu"])
+                self.exemplum_url = model_url
+        
+        api.showMessage('Loading example image...')
+        image_url = 'https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/v0.1.1/specs/models/unet2d/nuclei_broad/cover0.png'
+        if self.img_url != image_url:
+            self.input_img = imread(image_url)
+            assert self.input_img.shape[2] == 4
+            self.img_url = image_url
 
-  async run(ctx) {
+        batch = self.input_img[None, :512, :512, 0]  # cyx
+        api.showMessage('Running model inference...')
+        prediction = self.exemplum.forward(batch)
 
-  }
-}
+        api.showMessage('Displaying results...')
+        imgurl1 = array2base64(self.input_img[:512, :512, 0])
+        imgurl2 = array2base64(prediction[0])
+        api.showMessage('Done.')
+        api.showDialog({'type': 'imjoy/image-compare', 'name': 'Ilastik Demo', 'data': {"first": imgurl1, 'second': imgurl2, 'name': 'Process with frangiVesselness in ImageJ'}})
     
-    api.export(new ImJoyPlugin())
-    </script>
+    def runManyModels(self, model_config_list):
+        api.alert('This feature is not implemented yet, please try the Ilastik icon on a individual model.')
+        api.log(str(model_config_list))
+
+    def run(self, ctx):
+        self.runOneModel({"download_url": "https://github.com/bioimage-io/pytorch-bioimage-io/releases/download/v0.1.1/UNet2DNucleiBroad.model.zip"})
+
+
+api.export(ImJoyPlugin())
+</script>
+  


### PR DESCRIPTION
This PR adds a Ilastik Model Loader based on the example here: https://github.com/ilastik/tiktorch/pull/88/files

You can try it directly in ImJoy: https://imjoy.io/#/app?plugin=https://raw.githubusercontent.com/bioimage-io/models/ffaaa0f43f574f46906527557c9559a903ef32d4/src/Ilastik-app.imjoy.html

![Ilastik-demo-0 1 0](https://user-images.githubusercontent.com/478667/75494895-8f888000-59bd-11ea-84e1-7254d9e14855.gif)

For running on MyBinder.org (which is the default python plugin engine for the BioEngine ), I made a repo contains a requirements file with the following two pip libraries:
```
git+git://github.com/bioimage-io/pytorch-bioimage-io.git#egg=pybio.torch
git+git://github.com/ilastik/tiktorch.git#egg=tiktorch
```