### PR TITLE
Configure CI to run for every 2h

### DIFF
--- a/.github/workflows/compile-manifest.yml
+++ b/.github/workflows/compile-manifest.yml
@@ -41,7 +41,7 @@ jobs:
     
   deploy-manifest:
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-manifest
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Load saved build output

--- a/.github/workflows/compile-manifest.yml
+++ b/.github/workflows/compile-manifest.yml
@@ -8,7 +8,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-
+  schedule:
+    - cron:  '0 */2 * * *'
 jobs:
   build-manifest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is to update the manifest file every 2h,

TODO: we need to make some rules on what field can be changed, for example, perhaps it's ok to update the name and description, or add weights to the list, but perhaps we should not allow changing the model id or sha256 value of the model. (The author will need to send a PR.)