### PR TITLE
Add HPA as community partner

### DIFF
--- a/src/manifest.bioimage.io.yaml
+++ b/src/manifest.bioimage.io.yaml
@@ -33,6 +33,8 @@ collection:
     source: https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/manifest.bioimage.io.yaml
   - id: ilastik
     source: https://raw.githubusercontent.com/ilastik/bioimage-io-models/master/manifest.bioimage.io.yaml
+  - id: hpa
+    source: https://raw.githubusercontent.com/CellProfiling/HPA-model-zoo/master/manifest.bioimage.io.yaml
 
 application: []
 


### PR DESCRIPTION
We will add the models from our previous HPA Kaggle challenge into BioImage.IO: https://github.com/CellProfiling/HPA-model-zoo
