### PR TITLE
Update package name to bioimageio

### DIFF
--- a/utils/compile_model_manifest.py
+++ b/utils/compile_model_manifest.py
@@ -6,7 +6,7 @@ import json
 import traceback
 import argparse
 from pathlib import Path
-from pybio.spec import __main__ as spec
+from bioimageio.spec import __main__ as spec
 from marshmallow import ValidationError
 
 preserved_keys = [


### PR DESCRIPTION
The python package name has changed to `bioimageio`, and it cause issues in the compilation script, e.g.: https://github.com/HenriquesLab/ZeroCostDL4Mic/runs/2612007713

