### PR TITLE
add QuPath

### DIFF
--- a/collection.yaml
+++ b/collection.yaml
@@ -60,3 +60,20 @@ collection:
       Microscopy
   documentation: https://raw.githubusercontent.com/stardist/stardist/master/README.md
   tags: [stardist]
+- id: qupath
+  name: QuPath
+  description: "QuPath is an open, powerful, flexible, extensible software platform for bioimage analysis."
+  format_version: 0.2.2
+  git_repo: "https://github.com/qupath/qupath"
+  type: application
+  authors:
+    - name: Pete Bankhead
+      github_user: petebankhead
+  maintainers:
+    - name: Pete Bankhead
+      github_user: petebankhead
+  cite:
+  - doi: "10.1038/s41598-017-17204-5"
+    text: "QuPath: Open source software for digital pathology image analysis"
+  documentation: "https://raw.githubusercontent.com/qupath/qupath/main/README.md"
+  tags: [qupath]


### PR DESCRIPTION
This PR adds a resource entry to the bioimageio collection to represent the QuPath application. Through bioimageio/collection-bioimage-io this will be shown on bioimage.io