### PR TITLE
add qupath cover image

### DIFF
--- a/collection.yaml
+++ b/collection.yaml
@@ -76,4 +76,5 @@ collection:
   - doi: "10.1038/s41598-017-17204-5"
     text: "QuPath: Open source software for digital pathology image analysis"
   documentation: "https://raw.githubusercontent.com/qupath/qupath/main/README.md"
+  covers: ["https://qupath.readthedocs.io/en/latest/_static/qupath_128.png"]
   tags: [qupath]


### PR DESCRIPTION
@petebankhead any other image suggestion?
only image related to qupath I could find so far is: https://qupath.readthedocs.io/en/latest/_static/qupath_128.png