### PR TITLE
Add missing license field to qupath reference

### DIFF
--- a/collection.bioimage.io.yaml
+++ b/collection.bioimage.io.yaml
@@ -77,6 +77,7 @@ collection:
   cite:
   - doi: "10.1038/s41598-017-17204-5"
     text: "QuPath: Open source software for digital pathology image analysis"
+  license: "GPL-3.0-only"
   documentation: "https://raw.githubusercontent.com/qupath/qupath/main/README.md"
   covers: ["https://raw.githubusercontent.com/qupath/qupath/e96e7f228c2a9e27e7236108808540a4dbf503e8/qupath-gui-fx/src/main/resources/icons/QuPath_512.png"]
   icon: "https://raw.githubusercontent.com/qupath/qupath/e96e7f228c2a9e27e7236108808540a4dbf503e8/qupath-gui-fx/src/main/resources/icons/QuPath_64.png"

--- a/collection.bioimage.io.yaml
+++ b/collection.bioimage.io.yaml
@@ -77,7 +77,7 @@ collection:
   cite:
   - doi: "10.1038/s41598-017-17204-5"
     text: "QuPath: Open source software for digital pathology image analysis"
-  license: "GPL-3.0-only"
+  license: "GPL-3.0-or-later"
   documentation: "https://raw.githubusercontent.com/qupath/qupath/main/README.md"
   covers: ["https://raw.githubusercontent.com/qupath/qupath/e96e7f228c2a9e27e7236108808540a4dbf503e8/qupath-gui-fx/src/main/resources/icons/QuPath_512.png"]
   icon: "https://raw.githubusercontent.com/qupath/qupath/e96e7f228c2a9e27e7236108808540a4dbf503e8/qupath-gui-fx/src/main/resources/icons/QuPath_64.png"


### PR DESCRIPTION
took license info from https://github.com/qupath/qupath/blob/main/LICENSE
Assuming gpl 3 only (not 'or later') is applicable